### PR TITLE
Fix crash when a line chart has no point values

### DIFF
--- a/chartist-plugin-tooltip2.js
+++ b/chartist-plugin-tooltip2.js
@@ -105,6 +105,10 @@
                     // Offer support for multiple series line charts
                     if (chart instanceof Chartist.Line) {
                         chart.on('created', function() {
+                            if (pointValues.length === 0) {
+                                return;
+                            }
+
                             chart.container.querySelector('svg').addEventListener('mousemove', prepareLineTooltip);
                             chart.container.addEventListener('mouseleave', function(e) {
                                 var pointElement = chart.container.querySelector('.' + chart.options.classNames.point + '--hover');


### PR DESCRIPTION
The call to `getClosestNumberFromArray` crashes when a chart has no values because `reduce` attemps to use the first element of the array has the initial value.